### PR TITLE
Add Sakoe-Chiba band constraint

### DIFF
--- a/sdtw/distance.py
+++ b/sdtw/distance.py
@@ -31,7 +31,7 @@ class SquaredEuclidean(object):
         """
         return euclidean_distances(self.X, self.Y, squared=True)
 
-    def jacobian_product(self, E, sakoe_chiba_band=-1):
+    def jacobian_product(self, E):
         """
         Compute the product between the Jacobian
         (a linear map from m x d to m x n) and a matrix E.
@@ -41,11 +41,6 @@ class SquaredEuclidean(object):
         E: array, shape = [m, n]
             Second time series.
 
-        sakoe_chiba_band: int
-            If non-negative, the Jacobian product is restricted to a
-            Sakoe-Chiba band around the diagonal, in E.
-            The band has a width of 2 * sakoe_chiba_band + 1.
-
         Returns
         -------
         G: array, shape = [m, d]
@@ -54,10 +49,6 @@ class SquaredEuclidean(object):
         """
         G = np.zeros_like(self.X)
 
-        if sakoe_chiba_band >= 0:
-            assert E.shape[0] == E.shape[1]
-
-        _jacobian_product_sq_euc(self.X, self.Y, E, G,
-                                 sakoe_chiba_band=sakoe_chiba_band)
+        _jacobian_product_sq_euc(self.X, self.Y, E, G)
 
         return G

--- a/sdtw/distance.py
+++ b/sdtw/distance.py
@@ -4,6 +4,7 @@ from sklearn.metrics.pairwise import euclidean_distances
 
 from .soft_dtw_fast import _jacobian_product_sq_euc
 
+
 class SquaredEuclidean(object):
 
     def __init__(self, X, Y):
@@ -30,7 +31,7 @@ class SquaredEuclidean(object):
         """
         return euclidean_distances(self.X, self.Y, squared=True)
 
-    def jacobian_product(self, E):
+    def jacobian_product(self, E, sakoe_chiba_band=-1):
         """
         Compute the product between the Jacobian
         (a linear map from m x d to m x n) and a matrix E.
@@ -40,6 +41,11 @@ class SquaredEuclidean(object):
         E: array, shape = [m, n]
             Second time series.
 
+        sakoe_chiba_band: int
+            If non-negative, the Jacobian product is restricted to a
+            Sakoe-Chiba band around the diagonal, in E.
+            The band has a width of 2 * sakoe_chiba_band + 1.
+
         Returns
         -------
         G: array, shape = [m, d]
@@ -48,6 +54,10 @@ class SquaredEuclidean(object):
         """
         G = np.zeros_like(self.X)
 
-        _jacobian_product_sq_euc(self.X, self.Y, E, G)
+        if sakoe_chiba_band >= 0:
+            assert E.shape[0] == E.shape[1]
+
+        _jacobian_product_sq_euc(self.X, self.Y, E, G,
+                                 sakoe_chiba_band=sakoe_chiba_band)
 
         return G

--- a/sdtw/soft_dtw.py
+++ b/sdtw/soft_dtw.py
@@ -39,9 +39,6 @@ class SoftDTW(object):
         self.gamma = gamma
         self.sakoe_chiba_band = sakoe_chiba_band
 
-        if sakoe_chiba_band >= 0:
-            assert self.D.shape[0] == self.D.shape[1]
-
     def compute(self):
         """
         Compute soft-DTW by dynamic programming.

--- a/sdtw/soft_dtw_fast.pyx
+++ b/sdtw/soft_dtw_fast.pyx
@@ -36,7 +36,8 @@ cdef inline double _softmin3(double a,
 
 def _soft_dtw(np.ndarray[double, ndim=2] D,
               np.ndarray[double, ndim=2] R,
-              double gamma):
+              double gamma,
+              int sakoe_chiba_band=-1):
 
     cdef int m = D.shape[0]
     cdef int n = D.shape[1]
@@ -57,17 +58,25 @@ def _soft_dtw(np.ndarray[double, ndim=2] D,
     # DP recursion.
     for i in range(1, m + 1):
         for j in range(1, n + 1):
-            # D is indexed starting from 0.
-            R[i, j] = D[i-1, j-1] + _softmin3(R[i-1, j],
-                                              R[i-1, j-1],
-                                              R[i, j-1],
-                                              gamma)
+
+            # restrict the wrapping to a band around the diagonal
+            is_in_band = (j >= i - sakoe_chiba_band and
+                          j <= i + sakoe_chiba_band)
+            if sakoe_chiba_band >= 0 and not is_in_band:
+                R[i, j] = DBL_MAX
+            else:
+                # D is indexed starting from 0.
+                R[i, j] = D[i-1, j-1] + _softmin3(R[i-1, j],
+                                                  R[i-1, j-1],
+                                                  R[i, j-1],
+                                                  gamma)
 
 
 def _soft_dtw_grad(np.ndarray[double, ndim=2] D,
                    np.ndarray[double, ndim=2] R,
                    np.ndarray[double, ndim=2] E,
-                   double gamma):
+                   double gamma,
+                   int sakoe_chiba_band=-1):
 
     # We added an extra row and an extra column on the Python side.
     cdef int m = D.shape[0] - 1
@@ -95,21 +104,51 @@ def _soft_dtw_grad(np.ndarray[double, ndim=2] D,
     # DP recursion.
     for j in reversed(range(1, n+1)):  # ranges from n to 1
         for i in reversed(range(1, m+1)):  # ranges from m to 1
-            a = exp((R[i+1, j] - R[i, j] - D[i, j-1]) / gamma)
-            b = exp((R[i, j+1] - R[i, j] - D[i-1, j]) / gamma)
-            c = exp((R[i+1, j+1] - R[i, j] - D[i, j]) / gamma)
-            E[i, j] = E[i+1, j] * a + E[i, j+1] * b + E[i+1,j+1] * c
+
+            # restrict the wrapping to a band around the diagonal
+            is_in_band = (i >= j - sakoe_chiba_band and
+                          i <= j + sakoe_chiba_band)
+            if sakoe_chiba_band >= 0 and not is_in_band:
+                E[i, j] = 0
+                R[i, j] = -DBL_MAX
+            else:
+                if E[i+1, j] == 0:
+                    a = 0
+                else:
+                    a = exp((R[i+1, j] - R[i, j] - D[i, j-1]) / gamma)
+
+                if E[i, j+1] == 0:
+                    b = 0
+                else:
+                    b = exp((R[i, j+1] - R[i, j] - D[i-1, j]) / gamma)
+
+                if E[i+1,j+1] == 0:
+                    c = 0
+                else:
+                    c = exp((R[i+1, j+1] - R[i, j] - D[i, j]) / gamma)
+
+                E[i, j] = E[i+1, j] * a + E[i, j+1] * b + E[i+1,j+1] * c
 
 
 def _jacobian_product_sq_euc(np.ndarray[double, ndim=2] X,
                              np.ndarray[double, ndim=2] Y,
                              np.ndarray[double, ndim=2] E,
-                             np.ndarray[double, ndim=2] G):
+                             np.ndarray[double, ndim=2] G,
+                             int sakoe_chiba_band=-1):
     cdef int m = X.shape[0]
     cdef int n = Y.shape[0]
     cdef int d = X.shape[1]
+    cdef int i, j, k
+    cdef int is_in_band
 
     for i in range(m):
         for j in range(n):
+
+            # restrict the wrapping to a band around the diagonal
+            is_in_band = (j >= i - sakoe_chiba_band and
+                          j <= i + sakoe_chiba_band)
+            if sakoe_chiba_band >= 0 and not is_in_band:
+                continue
+
             for k in range(d):
                 G[i, k] += E[i,j] * 2 * (X[i, k] - Y[j, k])

--- a/sdtw/tests/test_soft_dtw.py
+++ b/sdtw/tests/test_soft_dtw.py
@@ -5,7 +5,6 @@ from scipy.optimize import approx_fprime
 from sklearn.metrics.pairwise import euclidean_distances
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_almost_equal
-from sklearn.utils.testing import assert_raises
 
 from sdtw.path import gen_all_paths
 from sdtw.distance import SquaredEuclidean
@@ -16,12 +15,6 @@ rng = np.random.RandomState(0)
 X = rng.randn(5, 4)
 Y = rng.randn(6, 4)
 D = euclidean_distances(X, Y, squared=True)
-
-# Generate two inputs with same length.
-rng = np.random.RandomState(0)
-Xs = rng.randn(6, 4)
-Ys = rng.randn(6, 4)
-Ds = euclidean_distances(Xs, Ys, squared=True)
 
 
 def _softmax(z):
@@ -81,45 +74,42 @@ def test_soft_dtw_grad_X():
         assert_array_almost_equal(G, G_num, 5)
 
 
-def test_soft_dtw_band_check_squared():
-    # D is not squared
-    SoftDTW(D, 1, sakoe_chiba_band=-1)
-    assert_raises(AssertionError, SoftDTW, D, 1, 0)
-    assert_raises(AssertionError, SoftDTW, D, 1, 1)
-
-    # Ds is squared
-    SoftDTW(Ds, 1, sakoe_chiba_band=-1)
-    SoftDTW(Ds, 1, sakoe_chiba_band=0)
-    SoftDTW(Ds, 1, sakoe_chiba_band=1)
-
-
 def test_soft_dtw_grad_band():
     def make_func(gamma, sakoe_chiba_band):
         def func(d):
-            D_ = d.reshape(*Ds.shape)
+            D_ = d.reshape(*D.shape)
             return SoftDTW(D_, gamma, sakoe_chiba_band).compute()
         return func
 
     for gamma in (0.001, 0.01, 0.1, 1, 10, 100, 1000):
         for sakoe_chiba_band in [-1, 0, 1, 3]:
-            sdtw = SoftDTW(Ds, gamma, sakoe_chiba_band)
+            sdtw = SoftDTW(D, gamma, sakoe_chiba_band)
             sdtw.compute()
             E = sdtw.grad()
             func = make_func(gamma, sakoe_chiba_band)
-            E_num = approx_fprime(Ds.ravel(), func, 1e-6).reshape(*E.shape)
+            E_num = approx_fprime(D.ravel(), func, 1e-6).reshape(*E.shape)
             assert_array_almost_equal(E, E_num, 5)
 
 
 def _path_is_in_band(A, sakoe_chiba_band):
     if sakoe_chiba_band < 0:
         return True
-    A_in_band = np.tril(A, sakoe_chiba_band)
-    A_in_band = np.tril(A_in_band.T, sakoe_chiba_band).T
-    return np.all(A == A_in_band)
+
+    # construct a mask which is True inside the Sakoe-Chiba band
+    mm, nn = A.shape
+    ii = np.arange(mm)[:, None]
+    jj = np.arange(nn)[None, :]
+    mask = ii * (nn - 1) - jj * (mm - 1)
+    mask = np.abs(2 * mask) < (max(mm, nn) * (sakoe_chiba_band + 1))
+
+    if np.all(A[~mask] == 0):
+        print(A)
+
+    return np.all(A[~mask] == 0)
 
 
-def _soft_dtw_band_bf(Ds, gamma, sakoe_chiba_band):
-    costs = [np.sum(A * Ds) for A in gen_all_paths(Ds.shape[0], Ds.shape[1])
+def _soft_dtw_band_bf(D, gamma, sakoe_chiba_band):
+    costs = [np.sum(A * D) for A in gen_all_paths(D.shape[0], D.shape[1])
              if _path_is_in_band(A, sakoe_chiba_band)]
     return _softmin(costs, gamma)
 
@@ -127,5 +117,5 @@ def _soft_dtw_band_bf(Ds, gamma, sakoe_chiba_band):
 def test_soft_dtw_band():
     gamma = 0.01
     for sakoe_chiba_band in [-1, 0, 1, 2]:
-        assert_almost_equal(SoftDTW(Ds, gamma, sakoe_chiba_band).compute(),
-                            _soft_dtw_band_bf(Ds, gamma, sakoe_chiba_band))
+        assert_almost_equal(SoftDTW(D, gamma, sakoe_chiba_band).compute(),
+                            _soft_dtw_band_bf(D, gamma, sakoe_chiba_band))

--- a/sdtw/tests/test_soft_dtw.py
+++ b/sdtw/tests/test_soft_dtw.py
@@ -5,6 +5,7 @@ from scipy.optimize import approx_fprime
 from sklearn.metrics.pairwise import euclidean_distances
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_almost_equal
+from sklearn.utils.testing import assert_raises
 
 from sdtw.path import gen_all_paths
 from sdtw.distance import SquaredEuclidean
@@ -15,6 +16,12 @@ rng = np.random.RandomState(0)
 X = rng.randn(5, 4)
 Y = rng.randn(6, 4)
 D = euclidean_distances(X, Y, squared=True)
+
+# Generate two inputs with same length.
+rng = np.random.RandomState(0)
+Xs = rng.randn(6, 4)
+Ys = rng.randn(6, 4)
+Ds = euclidean_distances(Xs, Ys, squared=True)
 
 
 def _softmax(z):
@@ -36,6 +43,7 @@ def test_soft_dtw():
     for gamma in (0.001, 0.01, 0.1, 1, 10, 100, 1000):
         assert_almost_equal(SoftDTW(D, gamma).compute(),
                             _soft_dtw_bf(D, gamma=gamma))
+
 
 def test_soft_dtw_grad():
     def make_func(gamma):
@@ -71,3 +79,49 @@ def test_soft_dtw_grad_X():
         func = make_func(gamma)
         G_num = approx_fprime(X.ravel(), func, 1e-6).reshape(*G.shape)
         assert_array_almost_equal(G, G_num, 5)
+
+
+def test_soft_dtw_band_check_squared():
+    # D is not squared
+    SoftDTW(D, 1, sakoe_chiba_band=-1)
+    assert_raises(AssertionError, SoftDTW, D, 1, 0)
+    assert_raises(AssertionError, SoftDTW, D, 1, 1)
+
+    # Ds is squared
+    SoftDTW(Ds, 1, sakoe_chiba_band=-1)
+    SoftDTW(Ds, 1, sakoe_chiba_band=0)
+    SoftDTW(Ds, 1, sakoe_chiba_band=1)
+
+
+def test_soft_dtw_grad_band():
+    def make_func(gamma, sakoe_chiba_band):
+        def func(d):
+            D_ = d.reshape(*Ds.shape)
+            return SoftDTW(D_, gamma, sakoe_chiba_band).compute()
+        return func
+
+    for gamma in (0.001, 0.01, 0.1, 1, 10, 100, 1000):
+        for sakoe_chiba_band in [-1, 0, 1, 3]:
+            sdtw = SoftDTW(Ds, gamma, sakoe_chiba_band)
+            sdtw.compute()
+            E = sdtw.grad()
+            func = make_func(gamma, sakoe_chiba_band)
+            E_num = approx_fprime(Ds.ravel(), func, 1e-6).reshape(*E.shape)
+            assert_array_almost_equal(E, E_num, 5)
+
+
+def test_soft_dtw_band():
+    # a band of 0 means the DTW is restricted on the diagonal
+    dist = SoftDTW(Ds, gamma=1, sakoe_chiba_band=0).compute()
+    assert_array_almost_equal(dist, Ds.trace())
+
+    # increasing the band should reduce the dist
+    for sakoe_chiba_band in range(1, Ds.shape[0] // 2):
+        new_dist = SoftDTW(Ds, gamma=1, sakoe_chiba_band=1).compute()
+        assert dist >= new_dist
+        dist = new_dist
+
+    # having the max band should be indentical to no band at all
+    ref = SoftDTW(Ds, gamma=1, sakoe_chiba_band=-1).compute()
+    dist = SoftDTW(Ds, gamma=1, sakoe_chiba_band=Ds.shape[0] // 2).compute()
+    assert_array_almost_equal(dist, ref)

--- a/sdtw/tests/test_soft_dtw.py
+++ b/sdtw/tests/test_soft_dtw.py
@@ -102,9 +102,6 @@ def _path_is_in_band(A, sakoe_chiba_band):
     mask = ii * (nn - 1) - jj * (mm - 1)
     mask = np.abs(2 * mask) < (max(mm, nn) * (sakoe_chiba_band + 1))
 
-    if np.all(A[~mask] == 0):
-        print(A)
-
     return np.all(A[~mask] == 0)
 
 


### PR DESCRIPTION
This PR adds a Sakoe-Chiba band constraint [1], which constrains the path to stay in a band around the diagonal. For now it works only on squared DTW problems.

___
[1] Sakoe, H., & Chiba, S. (1978). Dynamic programming algorithm optimization for spoken word recognition. IEEE transactions on acoustics, speech, and signal processing, 26(1), 43-49.
